### PR TITLE
Remove direct query support

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -189,7 +189,7 @@ function step3($host, $user, $password, $update)
        // get databases
         if (
             $engine_requirement->isValidated() && $config_requirement->isValidated()
-            && $DB_list = $link->query("SHOW DATABASES")
+            && $DB_list = $link->doQuery("SHOW DATABASES")
         ) {
             while ($row = $DB_list->fetch_array()) {
                 if (
@@ -340,7 +340,7 @@ function step4($databasename, $newdatabasename)
                 prev_form($host, $user, $password);
             }
         } else { // try to create the DB
-            if ($link->query("CREATE DATABASE IF NOT EXISTS `" . $newdatabasename . "`")) {
+            if ($link->doQuery("CREATE DATABASE IF NOT EXISTS `" . $newdatabasename . "`")) {
                 echo "<p>" . __('Database created') . "</p>";
 
                 $select_db = $link->select_db($newdatabasename);

--- a/install/migrations/update_0.85.x_to_0.90.0.php
+++ b/install/migrations/update_0.85.x_to_0.90.0.php
@@ -96,14 +96,14 @@ function update085xto0900()
                 FROM `glpi_displaypreferences`
                 WHERE `itemtype` = '$type'";
 
-        if ($result = $DB->query($query)) {
+        if ($result = $DB->doQuery($query)) {
             if ($DB->numrows($result) > 0) {
                 while ($data = $DB->fetchAssoc($result)) {
                     $query = "SELECT MAX(`rank`)
                          FROM `glpi_displaypreferences`
                          WHERE `users_id` = '" . $data['users_id'] . "'
                                AND `itemtype` = '$type'";
-                    $result = $DB->query($query);
+                    $result = $DB->doQuery($query);
                     $rank   = $DB->result($result, 0, 0);
                     $rank++;
 
@@ -113,13 +113,13 @@ function update085xto0900()
                             WHERE `users_id` = '" . $data['users_id'] . "'
                                   AND `num` = '$newval'
                                   AND `itemtype` = '$type'";
-                        if ($result2 = $DB->query($query)) {
+                        if ($result2 = $DB->doQuery($query)) {
                             if ($DB->numrows($result2) == 0) {
                                  $query = "INSERT INTO `glpi_displaypreferences`
                                          (`itemtype` ,`num` ,`rank` ,`users_id`)
                                   VALUES ('$type', '$newval', '" . $rank++ . "',
                                           '" . $data['users_id'] . "')";
-                                 $DB->query($query);
+                                 $DB->doQuery($query);
                             }
                         }
                     }
@@ -130,7 +130,7 @@ function update085xto0900()
                     $query = "INSERT INTO `glpi_displaypreferences`
                                 (`itemtype` ,`num` ,`rank` ,`users_id`)
                          VALUES ('$type', '$newval', '" . $rank++ . "', '0')";
-                    $DB->query($query);
+                    $DB->doQuery($query);
                 }
             }
         }

--- a/install/migrations/update_0.90.x_to_9.1.0.php
+++ b/install/migrations/update_0.90.x_to_9.1.0.php
@@ -346,7 +346,7 @@ function update090xto910()
                   KEY `wwn` (`wwn`),
                   KEY `speed` (`speed`)
                 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
-        $DB->query($query);
+        $DB->doQuery($query);
     }
 
    /************** Kernel version for os *************/

--- a/install/migrations/update_9.1.x_to_9.2.0.php
+++ b/install/migrations/update_9.1.x_to_9.2.0.php
@@ -2284,7 +2284,7 @@ Regards,',
     ];
     foreach ($tables as $table => $fields) {
         $add = true;
-        $result = $DB->query("SHOW INDEX FROM `$table` WHERE Key_name='unicity'");
+        $result = $DB->doQuery("SHOW INDEX FROM `$table` WHERE Key_name='unicity'");
         if ($result && $DB->numrows($result)) {
             $row = $DB->fetchAssoc($result);
             if ($row['Non_unique'] == 1) {

--- a/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
+++ b/install/migrations/update_9.5.x_to_10.0.0/native_inventory.php
@@ -529,7 +529,7 @@ if (!$DB->tableExists('glpi_printerlogs')) {
                 $DB->quoteName('date')
             )
         );
-        $to_preserve_result = $DB->query($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
+        $to_preserve_result = $DB->doQuery($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
             $DB->delete(
                 'glpi_printerlogs',
@@ -609,7 +609,7 @@ if (!$DB->tableExists('glpi_networkportmetrics')) {
                 $DB->quoteName('date')
             )
         );
-        $to_preserve_result = $DB->query($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
+        $to_preserve_result = $DB->doQuery($to_preserve_sql->getValue())->fetch_all(MYSQLI_ASSOC);
         if (!empty($to_preserve_result)) { // If there is no entries to preserve, it means that table is empty, and nothing has to be deleted
             $DB->delete(
                 'glpi_networkportmetrics',

--- a/src/Api/API.php
+++ b/src/Api/API.php
@@ -1244,7 +1244,7 @@ abstract class API
                 WHERE $where
                 ORDER BY " . $DB->quoteName($params['sort']) . " " . $params['order'] . "
                 LIMIT " . (int)$params['start'] . ", " . (int)$params['list_limit'];
-        if ($result = $DB->query($query)) {
+        if ($result = $DB->doQuery($query)) {
             while ($data = $DB->fetchAssoc($result)) {
                 if ($add_keys_names) {
                     // Insert raw names into the data row
@@ -1265,7 +1265,7 @@ abstract class API
 
        // get result full row counts
         $count_query = "SELECT COUNT(*) FROM {$DB->quoteName($table)} $join WHERE $where";
-        $totalcount = $DB->query($count_query)->fetch_row()[0];
+        $totalcount = $DB->doQuery($count_query)->fetch_row()[0];
 
         if ($params['range'][0] > $totalcount) {
             $this->returnError(

--- a/src/Console/Migration/AppliancesPluginToCoreCommand.php
+++ b/src/Console/Migration/AppliancesPluginToCoreCommand.php
@@ -231,7 +231,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand
         ];
 
         foreach ($core_tables as $table) {
-            $result = $this->db->query('TRUNCATE ' . $this->db->quoteName($table));
+            $result = $this->db->doQuery('TRUNCATE ' . $this->db->quoteName($table));
 
             if (!$result) {
                 throw new \Symfony\Component\Console\Exception\RuntimeException(
@@ -289,7 +289,7 @@ class AppliancesPluginToCoreCommand extends AbstractCommand
         );
 
         $table  = Profile::getTable();
-        $result = $this->db->query(
+        $result = $this->db->doQuery(
             sprintf(
                 "UPDATE %s SET helpdesk_item_type = REPLACE(helpdesk_item_type, '%s', '%s')",
                 $this->db->quoteName($table),

--- a/src/Console/Migration/BuildMissingTimestampsCommand.php
+++ b/src/Console/Migration/BuildMissingTimestampsCommand.php
@@ -95,7 +95,7 @@ class BuildMissingTimestampsCommand extends AbstractCommand
 
             $target_date = $column === 'date_creation' ? 'MIN(`date_mod`)' : 'MAX(`date_mod`)';
 
-            $result = $this->db->query(
+            $result = $this->db->doQuery(
                 "
             UPDATE `$table`
             LEFT JOIN (

--- a/src/Console/Migration/DynamicRowFormatCommand.php
+++ b/src/Console/Migration/DynamicRowFormatCommand.php
@@ -134,7 +134,7 @@ class DynamicRowFormatCommand extends AbstractCommand
         };
 
         foreach ($this->iterate($tables, $progress_message) as $table) {
-            $result = $this->db->query(sprintf('ALTER TABLE %s ROW_FORMAT = DYNAMIC', $this->db->quoteName($table)));
+            $result = $this->db->doQuery(sprintf('ALTER TABLE %s ROW_FORMAT = DYNAMIC', $this->db->quoteName($table)));
 
             if (!$result) {
                 $message = sprintf(

--- a/src/Console/Migration/MyIsamToInnoDbCommand.php
+++ b/src/Console/Migration/MyIsamToInnoDbCommand.php
@@ -95,7 +95,7 @@ class MyIsamToInnoDbCommand extends AbstractCommand
             };
 
             foreach ($this->iterate($tables, $progress_message) as $table) {
-                $result = $this->db->query(sprintf('ALTER TABLE %s ENGINE = InnoDB', $this->db->quoteName($table)));
+                $result = $this->db->doQuery(sprintf('ALTER TABLE %s ENGINE = InnoDB', $this->db->quoteName($table)));
 
                 if (false === $result) {
                     $message = sprintf(

--- a/src/Console/Migration/RacksPluginToCoreCommand.php
+++ b/src/Console/Migration/RacksPluginToCoreCommand.php
@@ -405,7 +405,7 @@ class RacksPluginToCoreCommand extends AbstractCommand
         ];
 
         foreach ($core_tables as $table) {
-            $result = $this->db->query('TRUNCATE ' . $this->db->quoteName($table));
+            $result = $this->db->doQuery('TRUNCATE ' . $this->db->quoteName($table));
 
             if (!$result) {
                 throw new \Symfony\Component\Console\Exception\RuntimeException(

--- a/src/Console/Migration/TimestampsCommand.php
+++ b/src/Console/Migration/TimestampsCommand.php
@@ -182,7 +182,7 @@ class TimestampsCommand extends AbstractCommand
                // apply alter to table
                 $query = "ALTER TABLE " . $this->db->quoteName($table) . " " . $tablealter . ";\n";
 
-                $result = $this->db->query($query);
+                $result = $this->db->doQuery($query);
                 if (false === $result) {
                     $message = sprintf(
                         __('Migration of table "%s" failed with message "(%s) %s".'),

--- a/src/Console/Migration/UnsignedKeysCommand.php
+++ b/src/Console/Migration/UnsignedKeysCommand.php
@@ -211,7 +211,7 @@ class UnsignedKeysCommand extends AbstractCommand
                     $extra
                 );
 
-                $result = $this->db->query($query);
+                $result = $this->db->doQuery($query);
 
                 if ($result === false) {
                     $message = sprintf(

--- a/src/Console/Migration/Utf8mb4Command.php
+++ b/src/Console/Migration/Utf8mb4Command.php
@@ -169,7 +169,7 @@ class Utf8mb4Command extends AbstractCommand
             };
 
             foreach ($this->iterate($tables, $progress_message) as $table) {
-                $result = $this->db->query(
+                $result = $this->db->doQuery(
                     sprintf('ALTER TABLE %s CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci', $this->db->quoteName($table))
                 );
 

--- a/src/DBConnection.php
+++ b/src/DBConnection.php
@@ -566,7 +566,7 @@ class DBConnection extends CommonDBTM
     {
 
         if ($DBconnection->connected) {
-            $result = $DBconnection->query("SELECT UNIX_TIMESTAMP(MAX(`date_mod`)) AS max_date
+            $result = $DBconnection->doQuery("SELECT UNIX_TIMESTAMP(MAX(`date_mod`)) AS max_date
                                          FROM `glpi_logs`");
             if ($DBconnection->numrows($result) > 0) {
                  return $DBconnection->result($result, 0, "max_date");

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -350,7 +350,9 @@ class DBmysql
      */
     public function query($query)
     {
-        throw new \RuntimeException('Executing direct queries is not allowed!');
+        $e = new \RuntimeException('Executing direct queries is not allowed!');
+        var_export($e->getTraceAsString());
+        throw $e;
     }
 
     /**

--- a/src/DBmysql.php
+++ b/src/DBmysql.php
@@ -350,6 +350,22 @@ class DBmysql
      */
     public function query($query)
     {
+        throw new \RuntimeException('Executing direct queries is not allowed!');
+    }
+
+    /**
+     * Execute a MySQL query
+     *
+     * @param string $query Query to execute
+     *
+     * @var array   $CFG_GLPI
+     * @var array   $DEBUG_SQL
+     * @var integer $SQL_TOTAL_REQUEST
+     *
+     * @return mysqli_result|boolean Query result handler
+     */
+    public function doQuery($query)
+    {
         global $CFG_GLPI, $DEBUG_SQL, $SQL_TOTAL_REQUEST;
 
         $is_debug = isset($_SESSION['glpi_use_mode']) && ($_SESSION['glpi_use_mode'] == Session::DEBUG_MODE);
@@ -369,7 +385,7 @@ class DBmysql
             // no translation for error logs
             $error = "  *** MySQL query error:\n  SQL: " . $query . "\n  Error: " .
                    $this->dbh->error . "\n";
-            $error .= Toolbox::backtrace(false, 'DBmysql->query()', ['Toolbox::backtrace()']);
+            $error .= Toolbox::backtrace(false, 'DBmysql->doQuery()', ['Toolbox::backtrace()']);
 
             Toolbox::logSqlError($error);
 
@@ -404,7 +420,7 @@ class DBmysql
                     )
                 )
             );
-            $message .= Toolbox::backtrace(false, 'DBmysql->query()', ['Toolbox::backtrace()']);
+            $message .= Toolbox::backtrace(false, 'DBmysql->doQuery()', ['Toolbox::backtrace()']);
             Toolbox::logSqlWarning($message);
 
             ErrorHandler::getInstance()->handleSqlWarnings($this->last_query_warnings, $query);
@@ -429,7 +445,7 @@ class DBmysql
      */
     public function queryOrDie($query, $message = '')
     {
-        $res = $this->query($query);
+        $res = $this->doQuery($query);
         if (!$res) {
             //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
             $message = sprintf(
@@ -891,7 +907,7 @@ class DBmysql
         if (!$this->cache_disabled && $usecache && isset($this->field_cache[$table])) {
             return $this->field_cache[$table];
         }
-        $result = $this->query("SHOW COLUMNS FROM `$table`");
+        $result = $this->doQuery("SHOW COLUMNS FROM `$table`");
         if ($result) {
             if ($this->numrows($result) > 0) {
                 $this->field_cache[$table] = [];
@@ -1012,7 +1028,7 @@ class DBmysql
             $query = trim($query);
             if ($query != '') {
                 $query = htmlentities($query, ENT_COMPAT, 'UTF-8');
-                if (!$this->query($query)) {
+                if (!$this->doQuery($query)) {
                     return false;
                 }
                 if (!isCommandLine()) {
@@ -1110,7 +1126,7 @@ class DBmysql
     {
         $name          = addslashes($this->dbdefault . '.' . $name);
         $query         = "SELECT GET_LOCK('$name', 0)";
-        $result        = $this->query($query);
+        $result        = $this->doQuery($query);
         list($lock_ok) = $this->fetchRow($result);
 
         return (bool)$lock_ok;
@@ -1129,7 +1145,7 @@ class DBmysql
     {
         $name          = addslashes($this->dbdefault . '.' . $name);
         $query         = "SELECT RELEASE_LOCK('$name')";
-        $result        = $this->query($query);
+        $result        = $this->doQuery($query);
         list($lock_ok) = $this->fetchRow($result);
 
         return $lock_ok;
@@ -1322,7 +1338,7 @@ class DBmysql
      */
     public function insert($table, $params)
     {
-        $result = $this->query(
+        $result = $this->doQuery(
             $this->buildInsert($table, $params)
         );
         return $result;
@@ -1451,7 +1467,7 @@ class DBmysql
     public function update($table, $params, $where, array $joins = [])
     {
         $query = $this->buildUpdate($table, $params, $where, $joins);
-        $result = $this->query($query);
+        $result = $this->doQuery($query);
         return $result;
     }
 
@@ -1561,7 +1577,7 @@ class DBmysql
     public function delete($table, $where, array $joins = [])
     {
         $query = $this->buildDelete($table, $where, $joins);
-        $result = $this->query($query);
+        $result = $this->doQuery($query);
         return $result;
     }
 
@@ -1631,7 +1647,7 @@ class DBmysql
     public function truncateOrDie($table, $message = '')
     {
         $table_name = $this::quoteName($table);
-        $res = $this->query("TRUNCATE $table_name");
+        $res = $this->doQuery("TRUNCATE $table_name");
         if (!$res) {
            //TRANS: %1$s is the description, %2$s is the query, %3$s is the error message
             $message = sprintf(
@@ -1724,7 +1740,7 @@ class DBmysql
     protected function rollbackTo($name)
     {
         // No proper rollback to savepoint support in mysqli extension?
-        $result = $this->query('ROLLBACK TO ' . self::quoteName($name));
+        $result = $this->doQuery('ROLLBACK TO ' . self::quoteName($name));
         return $result !== false;
     }
 

--- a/src/DBmysqlIterator.php
+++ b/src/DBmysqlIterator.php
@@ -113,7 +113,14 @@ class DBmysqlIterator implements SeekableIterator, Countable
     public function execute($table, $crit = "", $debug = false)
     {
         $this->buildQuery($table, $crit, $debug);
-        $this->res = ($this->conn ? $this->conn->query($this->sql) : false);
+        $this->res = false;
+        if ($this->conn) {
+            if ($this->conn instanceof DBmysql) {
+                $this->res = $this->conn->doQuery($this->sql);
+            } else {
+                $this->res = $this->conn->query($this->sql);
+            }
+        }
         $this->count = $this->res instanceof \mysqli_result ? $this->conn->numrows($this->res) : 0;
         $this->setPosition(0);
         return $this;

--- a/src/DbUtils.php
+++ b/src/DbUtils.php
@@ -622,7 +622,7 @@ final class DbUtils
             return false;
         }
 
-        $result = $DB->query("SHOW INDEX FROM `$table`");
+        $result = $DB->doQuery("SHOW INDEX FROM `$table`");
 
         if ($result && $DB->numrows($result)) {
             while ($data = $DB->fetchAssoc($result)) {

--- a/src/Migration.php
+++ b/src/Migration.php
@@ -557,7 +557,7 @@ class Migration
         global $DB;
 
         if ($DB->tableExists($table)) {
-            $DB->query("DROP TABLE `$table`");
+            $DB->doQuery("DROP TABLE `$table`");
         }
     }
 
@@ -724,7 +724,7 @@ class Migration
         ) {
            // Try to do a flush tables if RELOAD privileges available
            // $query = "FLUSH TABLES `$oldtable`, `$newtable`";
-           // $DB->query($query);
+           // $DB->doQuery($query);
 
             $query = "CREATE TABLE `$newtable` LIKE `$oldtable`";
             $DB->queryOrDie($query, $this->version . " create $newtable");
@@ -872,7 +872,7 @@ class Migration
         $sql = "SELECT MAX(`ranking`) AS `rank`
               FROM `glpi_rules`
               WHERE `sub_type` = '" . $rule['sub_type'] . "'";
-        $result = $DB->query($sql);
+        $result = $DB->doQuery($sql);
 
         $ranking = 1;
         if ($DB->numrows($result) > 0) {

--- a/src/NetworkPortMigration.php
+++ b/src/NetworkPortMigration.php
@@ -77,7 +77,7 @@ class NetworkPortMigration extends CommonDBChild
 
         if (countElementsInTable($this->getTable()) == 0) {
             $query = "DROP TABLE " . $DB->quoteName($this->getTable());
-            $DB->query($query);
+            $DB->doQuery($query);
         }
     }
 

--- a/src/Search/Provider/SQLProvider.php
+++ b/src/Search/Provider/SQLProvider.php
@@ -4156,10 +4156,10 @@ final class SQLProvider implements SearchProviderInterface
 
         // Use a ReadOnly connection if available and configured to be used
         $DBread = \DBConnection::getReadConnection();
-        $DBread->query("SET SESSION group_concat_max_len = 8194304;");
+        $DBread->doQuery("SET SESSION group_concat_max_len = 8194304;");
 
         $DBread->execution_time = true;
-        $result = $DBread->query($data['sql']['search']);
+        $result = $DBread->doQuery($data['sql']['search']);
 
         if ($result) {
             $data['data']['execution_time'] = $DBread->execution_time;
@@ -4185,7 +4185,7 @@ final class SQLProvider implements SearchProviderInterface
                     $data['data']['totalcount'] = $DBread->numrows($result);
                 } else {
                     foreach ($data['sql']['count'] as $sqlcount) {
-                        $result_num = $DBread->query($sqlcount);
+                        $result_num = $DBread->doQuery($sqlcount);
                         $data['data']['totalcount'] += $DBread->result($result_num, 0, 0);
                     }
                 }

--- a/src/System/Diagnostic/AbstractDatabaseChecker.php
+++ b/src/System/Diagnostic/AbstractDatabaseChecker.php
@@ -116,7 +116,7 @@ abstract class AbstractDatabaseChecker
     private function fetchTableColumns(string $table_name): void
     {
         if (!array_key_exists($table_name, $this->columns)) {
-            if (($columns_res = $this->db->query('SHOW COLUMNS FROM ' . $this->db->quoteName($table_name))) === false) {
+            if (($columns_res = $this->db->doQuery('SHOW COLUMNS FROM ' . $this->db->quoteName($table_name))) === false) {
                 throw new \Exception(sprintf('Unable to get table "%s" columns', $table_name));
             }
 
@@ -135,7 +135,7 @@ abstract class AbstractDatabaseChecker
     protected function getIndex(string $table_name): array
     {
         if (!array_key_exists($table_name, $this->indexes)) {
-            if (($keys_res = $this->db->query('SHOW INDEX FROM ' . $this->db->quoteName($table_name))) === false) {
+            if (($keys_res = $this->db->doQuery('SHOW INDEX FROM ' . $this->db->quoteName($table_name))) === false) {
                 throw new \Exception(sprintf('Unable to get table "%s" index', $table_name));
             }
 

--- a/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/src/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -358,7 +358,7 @@ class DatabaseSchemaIntegrityChecker
      */
     protected function getEffectiveCreateTableSql(string $table_name): string
     {
-        if (($create_table_res = $this->db->query('SHOW CREATE TABLE ' . $this->db->quoteName($table_name))) === false) {
+        if (($create_table_res = $this->db->doQuery('SHOW CREATE TABLE ' . $this->db->quoteName($table_name))) === false) {
             if ($this->db->errno() == 1146) {
                 return ''; // Table does not exists, effective create table is empty (will output full proper query as diff).
             }

--- a/src/System/Requirement/DbConfiguration.php
+++ b/src/System/Requirement/DbConfiguration.php
@@ -59,7 +59,7 @@ class DbConfiguration extends AbstractRequirement
     {
         $query = 'SELECT @@GLOBAL.' . $this->db->quoteName('innodb_page_size as innodb_page_size');
 
-        if (($db_config_res = $this->db->query($query)) === false) {
+        if (($db_config_res = $this->db->doQuery($query)) === false) {
             $this->validated = false;
             $this->validation_messages[] = __('Unable to validate database configuration variables.');
         }

--- a/src/Update.php
+++ b/src/Update.php
@@ -223,7 +223,7 @@ class Update
             // e.g. with `NO_ZERO_DATE` flag `ALTER TABLE` operations fails when a row contains a `0000-00-00 00:00:00` datetime value.
             // Unitary removal of these flags is not pôssible as MySQL 8.0 triggers warning if
             // `STRICT_{ALL|TRANS}_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO` are not used all together.
-            $sql_mode = $DB->query(sprintf('SELECT @@sql_mode as %s', $DB->quoteName('sql_mode')))->fetch_assoc()['sql_mode'] ?? '';
+            $sql_mode = $DB->doQuery(sprintf('SELECT @@sql_mode as %s', $DB->quoteName('sql_mode')))->fetch_assoc()['sql_mode'] ?? '';
             $sql_mode_flags = array_filter(
                 explode(',', $sql_mode),
                 function (string $flag) {
@@ -239,7 +239,7 @@ class Update
                     );
                 }
             );
-            $DB->query(sprintf('SET SESSION sql_mode = %s', $DB->quote(implode(',', $sql_mode_flags))));
+            $DB->doQuery(sprintf('SET SESSION sql_mode = %s', $DB->quote(implode(',', $sql_mode_flags))));
         }
 
        // To prevent problem of execution time

--- a/src/XML.php
+++ b/src/XML.php
@@ -124,7 +124,7 @@ class XML
                 $this->ErrorString = "Error the query can't be a null string";
                 return -1;
             }
-            $result = $DB->query($strqry);
+            $result = $DB->doQuery($strqry);
 
             if ($result == false) {
                 $this->IsError     = 1;

--- a/tests/units/DB.php
+++ b/tests/units/DB.php
@@ -690,8 +690,8 @@ OTHER EXPRESSION;"
         $table = sprintf('glpitests_%s', uniqid());
         $this->when(
             function () use ($db, $create_query_template, $drop_query_template, $table) {
-                $db->query(sprintf($create_query_template, $table));
-                $db->query(sprintf($drop_query_template, $table));
+                $db->doQuery(sprintf($create_query_template, $table));
+                $db->doQuery(sprintf($drop_query_template, $table));
             }
         )->error()
             ->withType(E_USER_WARNING)
@@ -735,7 +735,7 @@ OTHER EXPRESSION;"
     {
         $db = new \mock\DB();
 
-        $db->query('SELECT 1/0');
+        $db->doQuery('SELECT 1/0');
         $this->array($db->getLastQueryWarnings())->isEqualTo(
             [
                 [
@@ -747,7 +747,7 @@ OTHER EXPRESSION;"
         );
         $this->hasSqlLogRecordThatContains('1365: Division by 0', LogLevel::WARNING);
 
-        $db->query('SELECT CAST("1a" AS SIGNED), CAST("123b" AS SIGNED)');
+        $db->doQuery('SELECT CAST("1a" AS SIGNED), CAST("123b" AS SIGNED)');
         $this->array($db->getLastQueryWarnings())->isEqualTo(
             [
                 [

--- a/tests/units/Glpi/System/Diagnostic/DatabaseKeysChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseKeysChecker.php
@@ -333,11 +333,11 @@ SQL
         class_alias(get_class($item_class), $itemtype);
 
         $this->newTestedInstance($DB);
-        $DB->query(sprintf($create_table_sql, $table_name));
+        $DB->doQuery(sprintf($create_table_sql, $table_name));
         $missing_keys  = $this->testedInstance->getMissingKeys($table_name);
         $misnamed_keys = $this->testedInstance->getMisnamedKeys($table_name);
         $useless_keys = $this->testedInstance->getUselessKeys($table_name);
-        $DB->query(sprintf('DROP TABLE `%s`', $table_name));
+        $DB->doQuery(sprintf('DROP TABLE `%s`', $table_name));
 
         $this->array($missing_keys)->isEqualTo($expected_missing);
         $this->array($misnamed_keys)->isEqualTo($expected_misnamed);

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaConsistencyChecker.php
@@ -96,9 +96,9 @@ SQL
         $table_name = sprintf('glpitests_%s', uniqid());
 
         $this->newTestedInstance($DB);
-        $DB->query(sprintf($create_table_sql, $table_name));
+        $DB->doQuery(sprintf($create_table_sql, $table_name));
         $missing_fields = $this->testedInstance->getMissingFields($table_name);
-        $DB->query(sprintf('DROP TABLE `%s`', $table_name));
+        $DB->doQuery(sprintf('DROP TABLE `%s`', $table_name));
 
         $this->array($missing_fields)->isEqualTo($expected_missing);
     }

--- a/tests/units/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
+++ b/tests/units/Glpi/System/Diagnostic/DatabaseSchemaIntegrityChecker.php
@@ -1233,7 +1233,7 @@ DIFF,
             $this->mockGenerator->orphanize('__construct');
             $query_result = new \mock\mysqli_result();
             $this->calling($query_result)->fetch_assoc = ['Create Table' => $effective_sql];
-            $this->calling($db)->query = $query_result;
+            $this->calling($db)->doQuery = $query_result;
 
             $this->boolean($this->testedInstance->hasDifferences($table_name, $raw_sql))->isEqualTo(!empty($expected_diff));
             $this->string($this->testedInstance->getDiff($table_name, $raw_sql))->isEqualTo($expected_diff);
@@ -1292,7 +1292,7 @@ DIFF,
         $db = $this->geDbMock();
         $db->use_utf8mb4 = $args['use_utf8mb4'];
         $that = $this;
-        $this->calling($db)->query = function ($query) use ($effective_tables, $that) {
+        $this->calling($db)->doQuery = function ($query) use ($effective_tables, $that) {
             $table_name = preg_replace('/SHOW CREATE TABLE `([^`]+)`/', '$1', $query);
             if (array_key_exists($table_name, $effective_tables)) {
                 $that->mockGenerator->orphanize('__construct');
@@ -1383,7 +1383,7 @@ SQL,
             };
             $that = $this;
             $this->calling($db)->listTables = [['TABLE_NAME' => "glpi_{$table_prefix}unknowntable"]]; // $DB->listTables() is used to list unknown tables
-            $this->calling($db)->query = function ($query) use ($that, $table_prefix, $existingtable_sql, $unknowntable_sql) {
+            $this->calling($db)->doQuery = function ($query) use ($that, $table_prefix, $existingtable_sql, $unknowntable_sql) {
                 $table_name = preg_replace('/SHOW CREATE TABLE `([^`]+)`/', '$1', $query);
                 $result = null;
                 switch ($table_name) {
@@ -1490,7 +1490,7 @@ SQL;
         $that = $this;
 
         // Case 1: "DEFAULT ''" not returned by MySQL should not be detected as a difference for GLPI < 10.0.1
-        $this->calling($db)->query = function ($query) use ($that) {
+        $this->calling($db)->doQuery = function ($query) use ($that) {
             if (preg_match('/^SHOW CREATE TABLE/', $query) === 1) {
                 $that->mockGenerator->orphanize('__construct');
                 $res = new \mock\mysqli_result();
@@ -1554,7 +1554,7 @@ SQL
 
         // Case 2: "DEFAULT ''" returned by MariaDB should be detected as a difference for GLPI >= 10.0.1
         $db->use_utf8mb4 = true;
-        $this->calling($db)->query = function ($query) use ($that) {
+        $this->calling($db)->doQuery = function ($query) use ($that) {
             if (preg_match('/^SHOW CREATE TABLE/', $query) === 1) {
                 $that->mockGenerator->orphanize('__construct');
                 $res = new \mock\mysqli_result();
@@ -1644,7 +1644,7 @@ CREATE TABLE `glpi_notimportedemails` (
 SQL;
 
         $that = $this;
-        $this->calling($db)->query = function ($query) use ($that) {
+        $this->calling($db)->doQuery = function ($query) use ($that) {
             if (preg_match('/^SHOW CREATE TABLE/', $query) === 1) {
                 $that->mockGenerator->orphanize('__construct');
                 $res = new \mock\mysqli_result();
@@ -1738,7 +1738,7 @@ CREATE TABLE `glpi_notimportedemails` (
 SQL;
 
         $that = $this;
-        $this->calling($db)->query = function ($query) use ($that) {
+        $this->calling($db)->doQuery = function ($query) use ($that) {
             if (preg_match('/^SHOW CREATE TABLE/', $query) === 1) {
                 $that->mockGenerator->orphanize('__construct');
                 $res = new \mock\mysqli_result();

--- a/tests/units/Glpi/System/Requirement/DbConfiguration.php
+++ b/tests/units/Glpi/System/Requirement/DbConfiguration.php
@@ -153,7 +153,7 @@ class DbConfiguration extends \GLPITestCase
         $this->mockGenerator->orphanize('__construct');
         $db = new \mock\DB();
         $this->calling($db)->getVersion = $version;
-        $this->calling($db)->query = function ($query) use ($that, $variables) {
+        $this->calling($db)->doQuery = function ($query) use ($that, $variables) {
             $matches = [];
             if (preg_match_all('/@@GLOBAL\.`(?<name>[^`]+)`/', $query, $matches) > 0) {
                   $row = [];

--- a/tests/units/Migration.php
+++ b/tests/units/Migration.php
@@ -63,7 +63,7 @@ class Migration extends \GLPITestCase
             $this->db = new \mock\DB();
             $queries = [];
             $this->queries = &$queries;
-            $this->calling($this->db)->query = function ($query) use (&$queries) {
+            $this->calling($this->db)->doQuery = function ($query) use (&$queries) {
                 $queries[] = $query;
                 return true;
             };
@@ -842,7 +842,7 @@ class Migration extends \GLPITestCase
 
         $queries = [];
         $this->queries = &$queries;
-        $this->calling($this->db)->query = function ($query) use (&$queries) {
+        $this->calling($this->db)->doQuery = function ($query) use (&$queries) {
             if ($query === 'SHOW INDEX FROM `glpi_oldtable`') {
                   // Make DbUtils::isIndex return false
                   return false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #number

Calls to DBMysql::query throws an exception. New method DBMysql::doQuery has been added as a replacement, but its direct call really must be discouraged.

Note: the "debug" commit will be removed, I do not know why I do not have any stack trace whan an exception is throwed from command line; it's really annoying.